### PR TITLE
Add docker support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,8 +164,8 @@ cython_debug/
 containers/data/
 
 # secrets for SparkyBudget
-SparkyBudget/token.txt
-SparkyBudget/access_url.txt
-SparkyBudget/SparkyBudget.db
-SparkyBudget/output/
-SparkyBudget/certs/
+token.txt
+access_url.txt
+SparkyBudget.db
+output/
+certs/

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Make sure to tell VSCode to use your venv: https://code.visualstudio.com/docs/py
 
 To use local HTTPS, create self signed certicate and upload under `SparkyBudget\certs`. Then in your .env set `USE_INTERNAL_HTTPS` and `USE_SECURE_SESSION_COOKIE` both equal to `1`
 
-You can now use `(HTTPS) Python: SparkyBudget app` from VSCode to launc the web application
+You can now use `(HTTPS) Python: SparkyBudget app` from VSCode to launch the web application
 
 TODO: will need to enable dotenv to do this: Run using "python app.py" command. It uses 5000 port.
 
@@ -51,11 +51,17 @@ TODO: will need to enable dotenv to do this: Run using "python app.py" command. 
 Default User name: Sparky
 Default Password: Sparky
 
-These can be changed in your .env file vis `SPARKY_USER` and `SPARKY_PASS`
+These can be changed in your .env file via `SPARKY_USER` and `SPARKY_PASS`
 
 ## Docker
 
-TBD
+an example dockerfile and docker-compose.yaml are included at the root of the project. The docker version runs using gunicorn in a production build
+
+You can build the image via the following command: `sudo docker build -t sparkybudget .`
+
+And you can run it via docker-compose like so: `sudo docker compose up`
+
+You may need to change the the mounting paths for the database, output directory, and token.txt/access_url.txt. By default I expect them at the root, so you may wish to copy them out of the SparkyBudget directory up to the same level as the docker-compose.yaml
 
 ## Information on how it works and SimpleFin
 

--- a/SparkyBudget/requirements.txt
+++ b/SparkyBudget/requirements.txt
@@ -8,10 +8,12 @@ click==8.1.7
 colorama==0.4.6; platform_system == "Windows"
 flask==3.0.2
 flask-login==0.6.3
+gunicorn==21.2.0
 idna==3.6
 itsdangerous==2.1.2
 jinja2==3.1.3
 markupsafe==2.1.5
+packaging==23.2
 requests==2.31.0
 schedule==1.2.1
 urllib3==2.2.1

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,15 @@
+version: '3'
+services:
+  app:
+    container_name: sparkybudget
+    env_file:
+      - .env
+    image: sparkybudget
+    volumes:
+      - ./access_url.txt:/app/access_url.txt
+      - ./SparkyBudget.db:/app/SparkyBudget.db
+      - ./token.txt:/app/token.txt
+      - ./output:/app/output
+    ports:
+      - 5050:5000
+    restart: unless-stopped

--- a/dockerfile
+++ b/dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.10.13-alpine3.19
+WORKDIR /app
+
+COPY LICENSE.txt SparkyBudget/requirements.txt SparkyBudget/*.py ./
+COPY SparkyBudget/templates ./templates
+COPY SparkyBudget/static ./static
+RUN pip install -r ./requirements.txt
+ENV FLASK_ENV production
+
+EXPOSE 5000
+CMD ["gunicorn", "-b", ":5000", "app:app"]

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default"]
 strategy = ["cross_platform", "inherit_metadata"]
 lock_version = "4.4.1"
-content_hash = "sha256:3a3067cd4f9e4e8c240d864828e37f8065af8f799e7c03100e7af326f5f514ea"
+content_hash = "sha256:9016cb44b72d7cb0a0f0dfd6c0ad9db1e7d9be71d288650d3f0152af280f8a05"
 
 [[package]]
 name = "blinker"
@@ -115,6 +115,20 @@ files = [
 ]
 
 [[package]]
+name = "gunicorn"
+version = "21.2.0"
+requires_python = ">=3.5"
+summary = "WSGI HTTP Server for UNIX"
+groups = ["default"]
+dependencies = [
+    "packaging",
+]
+files = [
+    {file = "gunicorn-21.2.0-py3-none-any.whl", hash = "sha256:3213aa5e8c24949e792bcacfc176fef362e7aac80b76c56f6b5122bf350722f0"},
+    {file = "gunicorn-21.2.0.tar.gz", hash = "sha256:88ec8bff1d634f98e61b9f65bc4bf3cd918a90806c6f5c48bc5603849ec81033"},
+]
+
+[[package]]
 name = "idna"
 version = "3.6"
 requires_python = ">=3.5"
@@ -168,6 +182,17 @@ files = [
     {file = "MarkupSafe-2.1.5-cp310-cp310-win32.whl", hash = "sha256:d9fad5155d72433c921b782e58892377c44bd6252b5af2f67f16b194987338a4"},
     {file = "MarkupSafe-2.1.5-cp310-cp310-win_amd64.whl", hash = "sha256:bf50cd79a75d181c9181df03572cdce0fbb75cc353bc350712073108cba98de5"},
     {file = "MarkupSafe-2.1.5.tar.gz", hash = "sha256:d283d37a890ba4c1ae73ffadf8046435c76e7bc2247bbb63c00bd1a709c6544b"},
+]
+
+[[package]]
+name = "packaging"
+version = "23.2"
+requires_python = ">=3.7"
+summary = "Core utilities for Python packages"
+groups = ["default"]
+files = [
+    {file = "packaging-23.2-py3-none-any.whl", hash = "sha256:8c491190033a9af7e1d931d0b5dacc2ef47509b34dd0de67ed209b5203fc88c7"},
+    {file = "packaging-23.2.tar.gz", hash = "sha256:048fb0e9405036518eaaf48a55953c750c11e1a1b68e0dd1a9d62ed0c092cfc5"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "flask-login>=0.6.3",
     "requests>=2.31.0",
     "schedule>=1.2.1",
+    "gunicorn>=21.2.0",
 ]
 requires-python = "==3.10.*"
 readme = "README.md"


### PR DESCRIPTION
an example dockerfile and docker-compose.yaml are now included at the root of the project. The docker version runs using gunicorn in a production build

You can build the image via the following command: `sudo docker build -t sparkybudget .`

And you can run it via docker-compose like so: `sudo docker compose up`

You may need to change the the mounting paths for the database, output directory, and token.txt/access_url.txt. By default I expect them at the root, so you may wish to copy them out of the SparkyBudget directory up to the same level as the docker-compose.yaml