### PR TITLE
Housekeeping/cleanup v3

### DIFF
--- a/SparkyBudget/static/css/balance_details.css
+++ b/SparkyBudget/static/css/balance_details.css
@@ -122,8 +122,12 @@ table.dataTable tbody tr.odd:hover {
     background-color: #555555 !important;
 }
 
+div.dt-container div.dt-layout-cell {
+    padding: 0;
+}
+
 #balanceTable {
-    margin: 20px auto;
+    margin-bottom: 20px;
 }
 
 table.dataTable thead .sorting,

--- a/SparkyBudget/static/js/balance_summary.js
+++ b/SparkyBudget/static/js/balance_summary.js
@@ -13,10 +13,10 @@ $(document).ready(function () {
         var myChart = new Chart(ctx, {
             type: 'bar',
             data: {
-                labels: appState.labels,
+                labels: window.appState.labels,
                 datasets: [{
                     label: 'Balance',
-                    data: appState.balances,
+                    data: window.appState.balances,
                     backgroundColor: [
                         '#32A45F', // Color for the first account type
                         '#90EBFC', // Color for the second account type

--- a/SparkyBudget/static/js/transaction-edit.js
+++ b/SparkyBudget/static/js/transaction-edit.js
@@ -161,7 +161,7 @@ $(document).ready(function () {
 
 
     // Trigger aggregateData with the default option on page load
-    aggregateData(appState.transaction_data, selectedOption);
+    aggregateData(window.appState.transaction_data, selectedOption);
 
     function aggregateData(transaction_data, selectedOption) {
         // Initialize an object to store aggregated data
@@ -319,7 +319,7 @@ $(document).ready(function () {
     // Add change event listener to the dropdown for triggering aggregation
     $('#dropdown_select').on('change', function () {
         var selectedOption = $(this).val();
-        aggregateData(appState.transaction_data, selectedOption);
+        aggregateData(window.appState.transaction_data, selectedOption);
     });
 
 });

--- a/SparkyBudget/templates/balance_details.html.jinja
+++ b/SparkyBudget/templates/balance_details.html.jinja
@@ -6,7 +6,7 @@
     <title>Balance Details</title>
     <link rel="icon" type="image/x-icon" href="{{ url_for('static', filename='images/favicon.ico') }}">
     <!-- Add DataTables CSS -->
-    <link rel="stylesheet" href="https://cdn.datatables.net/1.11.5/css/jquery.dataTables.css">
+    <link rel="stylesheet" href="https://cdn.datatables.net/2.0.1/css/dataTables.dataTables.min.css">
     <!-- Your existing styles and scripts -->
     <link rel="stylesheet" href="{{ url_for('static', filename='css/balance_details.css') }}">
 </head>
@@ -36,7 +36,7 @@
     </table>
     <!-- Add DataTables JS after jQuery -->
     <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
-    <script src="https://cdn.datatables.net/1.11.5/js/jquery.dataTables.js"></script>
+    <script src="https://cdn.datatables.net/2.0.1/js/dataTables.min.js"></script>
     <script src="{{ url_for('static', filename='js/balance_details.js') }}"></script>
 </body>
 </html>

--- a/SparkyBudget/templates/balance_summary.html.jinja
+++ b/SparkyBudget/templates/balance_summary.html.jinja
@@ -7,10 +7,11 @@
     <link rel="icon" type="image/x-icon" href="{{ url_for('static', filename='images/favicon.ico') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/balance_summary.css') }}">
     <script>
-        const appState = {
-            labels: {{ labels | tojson}},
-            balances: {{ balances  | tojson }}
-        };
+        // merge any existing appState with the new data. since appState can be null, start with empty object as the base
+        window.appState = Object.assign({}, window.appState, {
+            labels: {{ labels | default(()) | tojson }},
+            balances: {{ balances | default(()) | tojson }}
+        });
     </script>
     <script src="{{ url_for('static', filename='js/balance_summary.js') }}"></script>
 </head>

--- a/SparkyBudget/templates/budget_summary.html.jinja
+++ b/SparkyBudget/templates/budget_summary.html.jinja
@@ -13,8 +13,10 @@
     <script src="https://cdn.datatables.net/select/1.3.4/js/dataTables.select.min.js"></script>
     <script src="https://editor.datatables.net/extensions/Editor/js/dataTables.editor.min.js"></script>
     <script>
-        const transactionYears = {{ transaction_years | default(()) | tojson }};
-        const transactionMonths = {{ transaction_months | default(()) | tojson }};
+        // have to keep these as var for now until I understand their purpose
+        // TODO: review this later
+        var transactionYears = {{ transaction_years | default(()) | tojson }};
+        var transactionMonths = {{ transaction_months | default(()) | tojson }};
     </script>
     <script src="{{ url_for('static', filename='js/budget_summary.js') }}"></script>
 </head>

--- a/SparkyBudget/templates/budget_summary.html.jinja
+++ b/SparkyBudget/templates/budget_summary.html.jinja
@@ -5,18 +5,22 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Budget Summary</title>
     <link rel="icon" type="image/x-icon" href="{{ url_for('static', filename='images/favicon.ico') }}">
+    <link rel="stylesheet" href="https://cdn.datatables.net/2.0.1/css/dataTables.dataTables.min.css">
+    <link rel="stylesheet" href="https://cdn.datatables.net/2.0.1/css/dataTables.jqueryui.css">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/budget_summary.css') }}">
     <!-- Your existing DataTable and other scripts -->
     <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
-    <script src="https://cdn.datatables.net/1.11.5/js/jquery.dataTables.min.js"></script>
-    <script src="https://cdn.datatables.net/buttons/2.1.5/js/dataTables.buttons.min.js"></script>
+    <script src="https://cdn.datatables.net/2.0.1/js/dataTables.min.js"></script>
+    <script src="https://cdn.datatables.net/buttons/3.0.0/js/dataTables.buttons.min.js"></script>
+    <script src="https://cdn.datatables.net/buttons/3.0.0/js/buttons.dataTables.min.js"></script>
     <script src="https://cdn.datatables.net/select/1.3.4/js/dataTables.select.min.js"></script>
     <script src="https://editor.datatables.net/extensions/Editor/js/dataTables.editor.min.js"></script>
     <script>
-        // have to keep these as var for now until I understand their purpose
-        // TODO: review this later
-        var transactionYears = {{ transaction_years | default(()) | tojson }};
-        var transactionMonths = {{ transaction_months | default(()) | tojson }};
+        // merge any existing appState with the new data. since appState can be null, start with empty object as the base
+        window.appState = Object.assign({}, window.appState, {
+            transactionYears: {{ transaction_years | default(()) | tojson }},
+            transactionMonths: {{ transaction_months | default(()) | tojson }}
+        });
     </script>
     <script src="{{ url_for('static', filename='js/budget_summary.js') }}"></script>
 </head>

--- a/SparkyBudget/templates/category_mgmt.html.jinja
+++ b/SparkyBudget/templates/category_mgmt.html.jinja
@@ -5,10 +5,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Category Management</title>
     <link rel="icon" type="image/x-icon" href="{{ url_for('static', filename='images/favicon.ico') }}">
-    <link rel="stylesheet" href="https://cdn.datatables.net/1.10.25/css/jquery.dataTables.min.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.13/css/select2.min.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css" />
     <link rel="stylesheet" href="{{ url_for('static', filename='css/category_mgmt.css') }}">
+    <link rel="stylesheet" href="https://cdn.datatables.net/2.0.1/css/dataTables.dataTables.min.css">
+    <link rel="stylesheet" href="https://cdn.datatables.net/2.0.1/css/dataTables.jqueryui.css">
 </head>
 <body>
     <a href="/" title="Go to Home">
@@ -50,7 +51,7 @@
         </table>
     </div>
     <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
-    <script src="https://cdn.datatables.net/1.10.25/js/jquery.dataTables.min.js"></script>
+    <script src="https://cdn.datatables.net/2.0.1/js/dataTables.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.13/js/select2.min.js"></script>
     <script src="{{ url_for('static', filename='js/category_mgmt.js') }}"></script>
 </body>

--- a/SparkyBudget/templates/index.html.jinja
+++ b/SparkyBudget/templates/index.html.jinja
@@ -14,9 +14,8 @@
     <script src="https://cdn.jsdelivr.net/npm/daterangepicker/daterangepicker.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.13/js/select2.min.js" defer></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-datalabels"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/chroma-js/2.1.1/chroma.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-datalabels@2.2.0/dist/chartjs-plugin-datalabels.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/chart.js@3.7.0"></script>
     <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.10.2/dist/umd/popper.min.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
 </head>

--- a/SparkyBudget/templates/transaction_edit.html.jinja
+++ b/SparkyBudget/templates/transaction_edit.html.jinja
@@ -5,7 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Budget Summary</title>
     <link rel="icon" type="image/x-icon" href="{{ url_for('static', filename='images/favicon.ico') }}">
-    <link rel="stylesheet" href="https://code.jquery.com/ui/1.13.2/themes/base/jquery-ui.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/daterangepicker/daterangepicker.min.css">
     <link rel="stylesheet" href="https://cdn.datatables.net/buttons/3.0.0/css/buttons.dataTables.min.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css">
@@ -102,9 +101,10 @@
     </table>
     <!-- Include DataTables initialization script with export options and date range filter -->
     <script>
-        const appState = {
+        // merge any existing appState with the new data. since appState can be null, start with empty object as the base
+        window.appState = Object.assign({}, window.appState, {
             transaction_data: {{ transaction_data | tojson | safe }}
-        };
+        });
     </script>
     <script src="{{ url_for('static', filename='js/transaction-edit.js') }}"></script>
 </body>


### PR DESCRIPTION
standardizes the datatables version for all instances it's used and refactors work for any python-to-javascript data sharing to use appState, allowing the appState to be mutated multiple times without it interfering with each other

planned next items: python linter and prettying up the login page