### PR TITLE
Feature/python linting currency formatting and bugfixes

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,29 @@
+{
+    "python.analysis.autoImportCompletions": true,
+    "python.languageServer": "Pylance",
+    "python.missingPackage.severity": "Warning",
+    "python.terminal.activateEnvInCurrentTerminal": false,
+    "mypy.dmypyExecutable": "${workspaceFolder}/.venv/bin/dmypy",
+    "black-formatter.args": [
+        "--line-length",
+        "119"
+    ],
+    "isort.args": ["--profile", "black"],
+    "[python]": {
+        "editor.tabSize": 4,
+        "editor.insertSpaces": true,
+        "editor.formatOnSave": true,
+        "editor.codeActionsOnSave": {
+            "source.organizeImports": "explicit",
+            "source.unusedImports": "explicit"
+        }
+    },
+    "python.analysis.diagnosticSeverityOverrides": {
+        "reportMissingParameterType": "information",
+        "reportMissingTypeStubs": "information",
+        "reportUnknownArgumentType": "information",
+        "reportUnknownMemberType": "information",
+        "reportUnknownParameterType": "information",
+        "reportUnknownVariableType": "information"
+      }
+}

--- a/SparkyBudget/static/js/index.js
+++ b/SparkyBudget/static/js/index.js
@@ -244,6 +244,10 @@ $(document).ready(function () {
 
 
 function editBudget(event, subcategory, currentBudget) {
+    const USDollar = new Intl.NumberFormat('en-US', {
+        style: 'currency',
+        currency: 'USD',
+    });
     console.log("Editing budget...", subcategory);
 
     const budgetValueElement = event.target;
@@ -254,11 +258,13 @@ function editBudget(event, subcategory, currentBudget) {
     // Create an input element
     const inputElement = document.createElement('input');
     inputElement.type = 'text';
+    inputElement.pattern = "^(\d)+(\.\d{1,2})?$";
+    inputElement.inputmode = "decimal";
     inputElement.value = currentBudget;
 
     // Create a span element
     const spanElement = document.createElement('span');
-    spanElement.textContent = currentBudget;
+    spanElement.textContent = USDollar.format(currentBudget);
 
     // Append the input and span elements to the container
     container.appendChild(inputElement);
@@ -272,11 +278,27 @@ function editBudget(event, subcategory, currentBudget) {
 
     // Add event listeners to handle blur and focusout events
     inputElement.addEventListener('blur', handleUpdate);
-    inputElement.addEventListener('focusout', handleUpdate);
+    //inputElement.addEventListener('focusout', (e) => handleUpdate(e));
 
     function handleUpdate() {
-        // Use function scope to access variables
-        updateBudget(subcategory, inputElement.value);
+        const budgetAmount = Number(inputElement.value);
+
+        if (Number.isNaN(budgetAmount) || budgetAmount === 0) {
+            // too lazy to do a modal
+            const resp = confirm('Invalid budget amount. Would you like to go back and fix or cancel?');
+            if(resp) {
+                setTimeout(() => {
+                    inputElement.focus();
+                }, 0);
+                return false;
+            } else {
+                updateBudgetSummaryChart();
+                return false;
+            }
+        } else {
+            // Use function scope to access variables
+            updateBudget(subcategory, inputElement.value);
+        }
 
         // Replace the container with the original budgetValueElement
         if (budgetValueElement.parentNode) {
@@ -352,6 +374,7 @@ function toggleAddBudgetForm() {
 }
 
 function addBudget() {
+    const addBudgetForm = document.getElementById('addBudgetForm');
     const budgetMonthInput = document.getElementById('budgetMonth');
     const budgetMonth = budgetMonthInput.value.trim();
     console.log("Inside add budget")
@@ -373,9 +396,24 @@ function addBudget() {
     // Continue with the rest of your logic for adding the budget
 
     // Get other input values (subcategory, budget amount, etc.)
-    //const subCategory = document.getElementById('subCategoryInput').value.trim();
+    const subCategorySelect = document.getElementById('subCategoryInput');
     const subCategory = $('#subCategoryInput').val();
-    const budgetAmount = document.getElementById('budgetAmountInput').value.trim();
+
+    if(!subCategory) {
+        subCategorySelect.setCustomValidity('Please select a budget category');
+        addBudgetForm.reportValidity();
+        return false;
+    }
+
+
+    const budgetAmountInput = document.getElementById('budgetAmountInput');
+    const budgetAmount = Number(budgetAmountInput.value.trim());
+
+    if (Number.isNaN(budgetAmount) || budgetAmount === 0) {
+        budgetAmountInput.setCustomValidity('Please enter a budget amount');
+        addBudgetForm.reportValidity();
+        return false;
+    }
 
     // You can perform additional validation for subcategory and budget amount if needed
 

--- a/SparkyBudget/templates/balance_details.html.jinja
+++ b/SparkyBudget/templates/balance_details.html.jinja
@@ -27,9 +27,9 @@
             <tr>
                 <td>{{ balance_details_data[0] }}</td>
                 <td>{{ balance_details_data[1] }}</td>
-                <td>{{ balance_details_data[2] }}</td>
-                <td>{{ balance_details_data[3] }}</td>
-                <td>{{ balance_details_data[4] }}</td>
+                <td>{{ balance_details_data[2].strftime("%B %-d, %Y") }}</td>
+                <td>{{ balance_details_data[3] | tocurrency }}</td>
+                <td>{{ balance_details_data[4] | tocurrency }}</td>
             </tr>
             {% endfor %}
         </tbody>

--- a/SparkyBudget/templates/balance_summary.html.jinja
+++ b/SparkyBudget/templates/balance_summary.html.jinja
@@ -31,8 +31,8 @@
                         <span class="expand-collapse-toggle"></span>
                         {{ data[0] }}
                     </td>
-                    <td>{{ data[1] }}</td>
-                    <td>{{ data[2] }}</td>
+                    <td>{{ data[1] | tocurrency }}</td>
+                    <td>{{ data[2] | tocurrency }}</td>
                 </tr>
                 {% for bank_data in account_type_banak_data %}
                     {% if bank_data[0] == data[0] %}

--- a/SparkyBudget/templates/budget_kpi_boxes.html.partial.jinja
+++ b/SparkyBudget/templates/budget_kpi_boxes.html.partial.jinja
@@ -1,22 +1,22 @@
 <div class="kpi boxes">
     <div class="box income" style="margin-top: 20px;">
         <h2>Income</h2>
-        <p>${{ budget_summary_kpi_boxes_data[0][0] }}</p>
+        <p>{{ budget_summary_kpi_boxes_data[0][0] | tocurrency }}</p>
     </div>
     <div class="box budget" style="margin-top: 20px;">
         <h2>Budget</h2>
-        <p>${{ budget_summary_kpi_boxes_data[0][1] }}</p>
+        <p>{{ budget_summary_kpi_boxes_data[0][1] | tocurrency }}</p>
     </div>
     <div class="box expense" style="margin-top: 20px;">
         <h2>Spent</h2>
-        <p>${{ budget_summary_kpi_boxes_data[0][2] }}</p>
+        <p>{{ budget_summary_kpi_boxes_data[0][2] | tocurrency }}</p>
     </div>
     <div class="box remaining" style="margin-top: 20px;">
         <h2>Budgeted Balance</h2>
-        <p>${{ budget_summary_kpi_boxes_data[0][3] }}</p>
+        <p>{{ budget_summary_kpi_boxes_data[0][3] | tocurrency }}</p>
     </div>
     <div class="box aremaining" style="margin-top: 20px;">
         <h2>Spent Balance</h2>
-        <p>${{ budget_summary_kpi_boxes_data[0][4] }}</p>
+        <p>{{ budget_summary_kpi_boxes_data[0][4] | tocurrency }}</p>
     </div>
 </div>

--- a/SparkyBudget/templates/budget_summary.html.jinja
+++ b/SparkyBudget/templates/budget_summary.html.jinja
@@ -44,8 +44,8 @@
                     <span class="budgetValue">{{ data[2] }}</span>
                     <input type="text" class="editInput" style="display:none;">
                 </td>
-                <td><a href="#" onclick="showTransactionDetails(event,'{{ data[1] }}')">{{ data[3] }}</a></td>
-                <td>{{ data[4] }}</td>
+                <td><a href="#" onclick="showTransactionDetails(event,'{{ data[1] }}')">{{ data[3] | tocurrency }}</a></td>
+                <td>{{ data[4] | tocurrency }}</td>
             </tr>
             {% endfor %}
         </tbody>

--- a/SparkyBudget/templates/budget_summary_chart.html.partial.jinja
+++ b/SparkyBudget/templates/budget_summary_chart.html.partial.jinja
@@ -45,14 +45,14 @@
         <div class="left-content">
             <i class="fas fa-trash delete-icon" onclick="deleteBudget('{{ data[1] }}')" style="color: #61DAFB;"></i>
             <p href="#" onclick="showTransactionDetails(event,'{{ data[1] }}','{{ data[3] }}')" style="color: #61DAFB;">
-                {{ data[1] }} - </p>
-            {{ data[3] }}
+                {{ data[1] }} -&nbsp;</p>
+            {{ data[3] | tocurrency }}
         </div>
         <div class="right-content">
             <p>
-                <span id="budgetValue_{{ loop.index }}" onclick="editBudget(event,  '{{ data[1] }}', '{{ data[2] }}')"
+                <span id="budgetValue_{{ loop.index }}" onclick="editBudget(event,  '{{ data[1] }}', {{ data[2] }})"
                     style="text-decoration: underline;">
-                    {{ data[2] }}
+                    {{ data[2] | tocurrency }}
                 </span>
             </p>
         </div>
@@ -68,7 +68,7 @@
         </div>
     </div>
     <div class="bottom-content">
-        Bal:{{ data[4] }}
+        Bal: {{ data[4] | tocurrency }}
     </div>
     {% endfor %}
 </div>

--- a/SparkyBudget/templates/index.html.jinja
+++ b/SparkyBudget/templates/index.html.jinja
@@ -106,7 +106,7 @@
                     <option value="" selected disabled>Select a subcategory</option>
                 </select>
                 <label for="budgetAmountInput">Budget Amount:</label>
-                <input type="text" id="budgetAmountInput" placeholder="Enter budget amount" required>
+                <input type="text" pattern="^(\d)+(\.\d{1,2})?$" inputmode="decimal" id="budgetAmountInput" placeholder="Enter budget amount" required>
                 <button type="button" onclick="addBudget()">Submit Budget</button>
             </form>
             <div id="budgetSummaryKPIContainer"></div>

--- a/SparkyBudget/templates/transaction_details.html.partial.jinja
+++ b/SparkyBudget/templates/transaction_details.html.partial.jinja
@@ -17,7 +17,7 @@
                 <td>{{ detail[2] }}</td>
                 <td>{{ detail[3] }}</td>
                 <td>{{ detail[4] }}</td>
-                <td>{{ detail[5] }}</td>
+                <td>{{ detail[5] | tocurrency }}</td>
                 <!-- Subcategory change option -->
                 <td>
                     <!-- Existing content -->

--- a/SparkyBudget/templates/transaction_edit.html.jinja
+++ b/SparkyBudget/templates/transaction_edit.html.jinja
@@ -88,7 +88,7 @@
                 <td>{{ transaction[5] }}</td>
                 <td>{{ transaction[6] }}</td>
                 <td>{{ transaction[7] }}</td>
-                <td>{{ transaction[8] }}</td>
+                <td>{{ transaction[8] | tocurrency }}</td>
                 <td>
                     <div class="subcategory-cell">
                         <button class="re-categorize-button">Re-categorize</button>

--- a/dockerfile
+++ b/dockerfile
@@ -1,11 +1,18 @@
-FROM python:3.10.13-alpine3.19
+FROM python:3.10.13-slim-bookworm
 WORKDIR /app
 
 COPY LICENSE.txt SparkyBudget/requirements.txt SparkyBudget/*.py ./
 COPY SparkyBudget/templates ./templates
 COPY SparkyBudget/static ./static
 RUN pip install -r ./requirements.txt
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends locales && \
+    apt-get -y autoremove && apt-get clean -y && rm -rf /var/lib/apt/lists/* && \
+    sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && locale-gen
 ENV FLASK_ENV production
+ENV LC_ALL en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
 
 EXPOSE 5000
 CMD ["gunicorn", "-b", ":5000", "app:app"]

--- a/mypy.ini
+++ b/mypy.ini
@@ -4,10 +4,12 @@
 warn_return_any = True
 warn_unused_configs = True
 disallow_untyped_defs = False
-disallow_any_unimported = True
+disallow_any_unimported = False
 check_untyped_defs = True
 show_error_codes = True
 warn_unused_ignores = True
 exclude = containers
 
 # Per-module options:
+[mypy-flask_login.*]
+ignore_missing_imports = True


### PR DESCRIPTION
changes:

* switch docker to Debian for better locale support (allows formatting currency)
* setup mypy, pylance, black, iosort settings for linting
* format currency on frontend js
* partial fix of issue that allowed sending in a blank category when creating a budget (would result in impossible to remove "Unknown" budget category)
* Add formatting to python along with a jinja helper "tocurrency" that a number can be passed to for formatting
    * fixes issue related to certain numbers showing as "None", now show as "--"
    * fixes issue where negative numbers would show as "$-AMOUNT", now will show as "-$AMOUNT"

TODO: database stuff needs primary keys and they should be used for any modifications to budget (delete, update amount, etc) to prevent unknowns. Keys in general need to be added in places to simplify code logic